### PR TITLE
Update gitstream.cm

### DIFF
--- a/.cm/gitstream.cm
+++ b/.cm/gitstream.cm
@@ -63,7 +63,7 @@ is:
 has:
   deleted_files: "{{ source.diff.files | map(attr='new_file') | match(term='/dev/null') | some }}"
 
-branch_prefix: "{{ branch.split('/')[0] }}"
+branch_prefix: "{{ branch[:branch.find('/')] if '/' in branch else branch }}"
 
 colors:
   red: "b60205"

--- a/.cm/gitstream.cm
+++ b/.cm/gitstream.cm
@@ -42,14 +42,13 @@ automations:
           label: "🗑️ Deleted files"
           color: "{{ colors.orange }}"
   
-  # Option 4
-  label_from_branch:
+  add_static_label:
     if:
       - true
     run:
       - action: add-label@v1
         args:
-          label: "{{ branch_prefix }}"
+          label: "test-label"
 
 calc:
   etr: "{{ branch | estimatedReviewTime }}"
@@ -62,8 +61,6 @@ is:
 
 has:
   deleted_files: "{{ source.diff.files | map(attr='new_file') | match(term='/dev/null') | some }}"
-
-branch_prefix: "{{ branch[:branch.find('/')] if '/' in branch else branch }}"
 
 colors:
   red: "b60205"

--- a/.cm/gitstream.cm
+++ b/.cm/gitstream.cm
@@ -42,13 +42,13 @@ automations:
           label: "🗑️ Deleted files"
           color: "{{ colors.orange }}"
   
-  add_static_label:
+  label_from_branch:
     if:
       - true
     run:
       - action: add-label@v1
         args:
-          label: "test-label"
+          label: "branch-{{ branch }}"
 
 calc:
   etr: "{{ branch | estimatedReviewTime }}"

--- a/.cm/gitstream.cm
+++ b/.cm/gitstream.cm
@@ -48,7 +48,7 @@ automations:
     run:
       - action: add-label@v1
         args:
-          label: "branch-{{ branch }}"
+          label: "{{ branch | split('/') | first }}"
 
 calc:
   etr: "{{ branch | estimatedReviewTime }}"

--- a/.cm/gitstream.cm
+++ b/.cm/gitstream.cm
@@ -49,6 +49,9 @@ automations:
       - action: add-label@v1
         args:
           label: "{{ branch_prefix }}"
+      - action: add-label@v1
+        args:
+          label: "{{ 'urgent' if is_hotfix else '' }}"
 
 calc:
   etr: "{{ branch | estimatedReviewTime }}"

--- a/.cm/gitstream.cm
+++ b/.cm/gitstream.cm
@@ -48,7 +48,7 @@ automations:
     run:
       - action: add-label@v1
         args:
-          label: "{{ branch | split('/') | first }}"
+          label: "{{ branch_prefix }}"
 
 calc:
   etr: "{{ branch | estimatedReviewTime }}"
@@ -61,6 +61,9 @@ is:
 
 has:
   deleted_files: "{{ source.diff.files | map(attr='new_file') | match(term='/dev/null') | some }}"
+
+branch_prefix: >
+  {{ branch.split('/')[0] if '/' in branch else branch }}
 
 colors:
   red: "b60205"


### PR DESCRIPTION
In this version:

We're still using a custom expression called branch_prefix. The expression now uses branch.find('/') to locate the first slash. If a slash is found, it takes everything before it. If not, it uses the whole branch name.

This approach avoids using the split() function, which might be causing issues.